### PR TITLE
Support tags set names with comma and double quotes, and projects without a tag set

### DIFF
--- a/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
+++ b/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
@@ -80,7 +80,7 @@ public class GraphToCsvUtils
 	{
 		writer.write( "id, label, timepoint, x, y, z, radius, parent_id" );
 		for ( TagSetStructure.TagSet tagSet : tagSets )
-			writer.write( ", " + tagSet.getName() );
+			writer.write( ", " + encodeString( tagSet.getName() ) );
 		writer.newLine();
 		writer.flush();
 	}
@@ -88,7 +88,7 @@ public class GraphToCsvUtils
 	private static void writeSpot( BufferedWriter writer, Spot spot, List< ObjTagMap< Spot, TagSetStructure.Tag > > tagMaps, Spot ref ) throws IOException
 	{
 		writer.write( spot.getInternalPoolIndex() + ", " );
-		writer.write( "\"" + spot.getLabel() + "\", " );
+		writer.write( encodeString( spot.getLabel() ) + ", " );
 		writer.write( spot.getTimepoint() + ", " );
 		writer.write( spot.getDoublePosition( 0 ) + ", " );
 		writer.write( spot.getDoublePosition( 1 ) + ", " );
@@ -98,6 +98,11 @@ public class GraphToCsvUtils
 		writeColors( writer, spot, tagMaps );
 		writer.newLine();
 		writer.flush();
+	}
+
+	private static String encodeString( String value )
+	{
+		return "\"" + value.replace( "\"", "\"\"" ) + "\"";
 	}
 
 	private static void writeColors( BufferedWriter writer, Spot spot, List< ObjTagMap< Spot, TagSetStructure.Tag > > tagMaps ) throws IOException

--- a/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
+++ b/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
@@ -110,6 +110,7 @@ public class StartBlenderWithCsvAction
 	private static String showSelectTagSetDialog( ProjectModel projectModel )
 	{
 		List< String > tagSets = projectModel.getModel().getTagSetModel().getTagSetStructure().getTagSets().stream().map( TagSetStructure.TagSet::getName ).collect( Collectors.toList() );
+		tagSets.add( 0, "[no tag set]" );
 		Object result = JOptionPane.showInputDialog( null, "Please select a tag set for visualization", "Blender Using Geometry Nodes",
 				JOptionPane.PLAIN_MESSAGE, null, tagSets.toArray(), tagSets.get( 0 ) );
 		return (String) result;

--- a/src/test/java/org/mastodon/blender/csv/GraphToCsvUtilsTest.java
+++ b/src/test/java/org/mastodon/blender/csv/GraphToCsvUtilsTest.java
@@ -1,0 +1,56 @@
+package org.mastodon.blender.csv;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Test;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.model.tag.TagSetStructure;
+import org.mastodon.util.TagHelper;
+import org.mastodon.util.TagSetUtils;
+
+public class GraphToCsvUtilsTest
+{
+	@Test
+	public void testWriteCsv() throws IOException
+	{
+		// setup
+		Model model = initializeExampleModel();
+		File csvFile = File.createTempFile( "mastodon-graph", ".csv" );
+		// process
+		GraphToCsvUtils.writeCsv( model, csvFile.getAbsolutePath() );
+		// test
+		String content = FileUtils.readFileToString( csvFile, StandardCharsets.UTF_8 );
+		String expected = "id, label, timepoint, x, y, z, radius, parent_id, \"tagset, with comma, and \"\"double quotes\"\"\"\n"
+				+ "0, \"spotA\", 0, 1.0, 2.0, 3.0, 1.0, , #AABBCC\n"
+				+ "1, \"spot,B\", 1, 3.0, 3.0, 4.0, 2.0, , #112233\n";
+		assertEquals( expected, content );
+	}
+
+	private static Model initializeExampleModel()
+	{
+		Model model = new Model();
+		TagSetStructure.TagSet tagSet = TagSetUtils.addNewTagSetToModel( model, "tagset, with comma, and \"double quotes\"", Arrays.asList(
+				Pair.of( "A", 0xaabbcc ),
+				Pair.of( "B", 0x112233 )
+		) );
+		TagHelper a = new TagHelper( model, tagSet, "A" );
+		TagHelper b = new TagHelper( model, tagSet, "B" );
+		ModelGraph graph = model.getGraph();
+		Spot spotA = graph.addVertex().init( 0, new double[] { 1, 2, 3 }, 1 );
+		Spot spotB = graph.addVertex().init( 1, new double[] { 3, 3, 4 }, 2 );
+		spotA.setLabel( "spotA" );
+		spotB.setLabel( "spot,B" );
+		a.tagSpot( spotA );
+		b.tagSpot( spotB );
+		return model;
+	}
+}


### PR DESCRIPTION
The "Open CSV in Blender..." command now no longer crashes if the tagset contains, commas, double quotes etc...

The main change is that strings in the exported CSV files (for tagset names and spot labels) are now correctly encoded, with double quotes.

![image](https://github.com/mastodon-sc/mastodon-blender-view/assets/24407711/bbd4d69c-af9a-465c-b2ba-ca42f499efa1)
