### PR TITLE
Custom Blender Template Files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,5 +180,10 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-ui-swing</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/org/mastodon/blender/Blender3dViewPlugin.java
+++ b/src/main/java/org/mastodon/blender/Blender3dViewPlugin.java
@@ -79,10 +79,10 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 
 	static
 	{
-		menuTexts.put( SHOW_IN_BLENDER, "New Interactive Blender Window" );
+		menuTexts.put( SHOW_IN_BLENDER, "Interactive Blender Window" );
 		menuTexts.put( SETUP_BLENDER, "Setup Blender Addon ..." );
 		menuTexts.put( EXPORT_CSV, "Export CSV for Blender" );
-		menuTexts.put( START_BLENDER_WITH_CSV, "Open CSV in Blender" );
+		menuTexts.put( START_BLENDER_WITH_CSV, "Geometry Nodes Blender Window" );
 		menuTexts.put( BLENDER_SETTINGS, "Configure Blender Template Files" );
 	}
 
@@ -142,13 +142,16 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 	{
 		return Arrays.asList(
 				menu( "Window",
-						item( SHOW_IN_BLENDER ) ),
+						menu( "New Blender Window",
+								item( SHOW_IN_BLENDER ),
+								item( START_BLENDER_WITH_CSV ) ) ),
 				menu( "Plugins",
 						menu( "Blender",
-								item( SHOW_IN_BLENDER ),
+								menu( "New Blender Window",
+										item( SHOW_IN_BLENDER ),
+										item( START_BLENDER_WITH_CSV ) ),
 								item( SETUP_BLENDER ),
 								item( BLENDER_SETTINGS ),
-								item( START_BLENDER_WITH_CSV ),
 								item( EXPORT_CSV ) ) ) );
 	}
 

--- a/src/main/java/org/mastodon/blender/Blender3dViewPlugin.java
+++ b/src/main/java/org/mastodon/blender/Blender3dViewPlugin.java
@@ -31,6 +31,7 @@ package org.mastodon.blender;
 import org.mastodon.app.ui.ViewMenuBuilder;
 import org.mastodon.blender.csv.ExportGraphAsCsvAction;
 import org.mastodon.blender.csv.StartBlenderWithCsvAction;
+import org.mastodon.blender.setup.BlenderSettingsCommand;
 import org.mastodon.blender.setup.BlenderSetup;
 import org.mastodon.mamut.KeyConfigScopes;
 import org.mastodon.mamut.ProjectModel;
@@ -38,6 +39,7 @@ import org.mastodon.mamut.plugin.MamutPlugin;
 import org.mastodon.ui.keymap.KeyConfigContexts;
 import org.scijava.AbstractContextual;
 import org.scijava.Context;
+import org.scijava.command.CommandService;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
 import org.scijava.ui.behaviour.io.gui.CommandDescriptionProvider;
@@ -65,6 +67,8 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 
 	private static final String SETUP_BLENDER = "[blender-3d-view] setup blender";
 
+	private static final String BLENDER_SETTINGS = "[blender-3d-view] blender settings";
+
 	private static final String EXPORT_CSV = "[blender-3d-view] export graph as csv";
 
 	private static final String START_BLENDER_WITH_CSV = "[blender-3d-view] start blender with csv";
@@ -79,6 +83,7 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 		menuTexts.put( SETUP_BLENDER, "Setup Blender Addon ..." );
 		menuTexts.put( EXPORT_CSV, "Export CSV for Blender" );
 		menuTexts.put( START_BLENDER_WITH_CSV, "Open CSV in Blender" );
+		menuTexts.put( BLENDER_SETTINGS, "Configure Blender Template Files" );
 	}
 
 	/*
@@ -97,6 +102,7 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 		{
 			descriptions.add( SHOW_IN_BLENDER, NO_KEYS, "Show the spots in a Blender 3D view." );
 			descriptions.add( SETUP_BLENDER, NO_KEYS, "Show a setup window that helps to configure Blender to be used from Mastodon." );
+			descriptions.add( BLENDER_SETTINGS, NO_KEYS, "Define template files to be used for the Mastodon Blender visualizations." );
 			descriptions.add( EXPORT_CSV, NO_KEYS, "Export the Graph As CSV" );
 			descriptions.add( START_BLENDER_WITH_CSV, NO_KEYS, "Export the graph as CSV and open it with Blender." );
 		}
@@ -105,6 +111,8 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 	private final AbstractNamedAction showInBlender;
 
 	private final AbstractNamedAction setupBlender;
+
+	private final AbstractNamedAction blenderSettings;
 
 	private final AbstractNamedAction exportCsv;
 
@@ -116,6 +124,7 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 	{
 		showInBlender = new RunnableAction( SHOW_IN_BLENDER, this::startBlenderView );
 		setupBlender = new RunnableAction( SETUP_BLENDER, this::showSetup );
+		blenderSettings = new RunnableAction( BLENDER_SETTINGS, this::showBlenderSettings );
 		exportCsv = new RunnableAction( EXPORT_CSV, this::exportCsv );
 		startBlenderWithCsv = new RunnableAction( START_BLENDER_WITH_CSV, this::startBlenderWithCsv );
 		updateEnabledActions();
@@ -138,6 +147,7 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 						menu( "Blender",
 								item( SHOW_IN_BLENDER ),
 								item( SETUP_BLENDER ),
+								item( BLENDER_SETTINGS ),
 								item( START_BLENDER_WITH_CSV ),
 								item( EXPORT_CSV ) ) ) );
 	}
@@ -153,6 +163,7 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 	{
 		actions.namedAction( showInBlender, NO_KEYS );
 		actions.namedAction( setupBlender, NO_KEYS );
+		actions.namedAction( blenderSettings, NO_KEYS );
 		actions.namedAction( exportCsv, NO_KEYS );
 		actions.namedAction( startBlenderWithCsv, NO_KEYS );
 	}
@@ -182,6 +193,11 @@ public class Blender3dViewPlugin extends AbstractContextual implements MamutPlug
 	private void showSetup()
 	{
 		new Thread(() -> BlenderSetup.showSetup( context ) ).start();
+	}
+
+	private void showBlenderSettings()
+	{
+		context.service( CommandService.class ).run( BlenderSettingsCommand.class, true );
 	}
 
 	private void exportCsv()

--- a/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
+++ b/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
@@ -43,11 +43,13 @@ import javax.swing.JOptionPane;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.mastodon.blender.StartBlenderException;
+import org.mastodon.blender.setup.BlenderSettingsService;
 import org.mastodon.blender.setup.BlenderSetup;
 import org.mastodon.blender.setup.StartBlender;
 import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.model.Model;
 import org.mastodon.model.tag.TagSetStructure;
+import org.scijava.Context;
 
 /**
  * Export the Mastodon graph as CSV file such that it can be opened with Blender.
@@ -99,12 +101,14 @@ public class StartBlenderWithCsvAction
 
 	private static void startBlenderWithCsv( ProjectModel projectModel, String tagset, String csv ) throws IOException
 	{
-		String blenderFile = copyResource( "/csv/empty_with_geometry_nodes.blend" );
+		Context context = projectModel.getContext();
+		BlenderSettingsService service = context.service( BlenderSettingsService.class );
+		String blenderFile = service.getCopyOfCsvBlenderTemplate().getAbsolutePath();
 		String pythonScript = copyResource( "/csv/read_csv.py" );
 		Map<String, String> environment = new HashMap<>();
 		environment.put( "MASTODON_BLENDER_CSV_FILE", csv );
 		environment.put( "MASTODON_BLENDER_TAG_SET", tagset );
-		StartBlender.startBlenderRunPythonScript( projectModel.getContext(), blenderFile, pythonScript, environment );
+		StartBlender.startBlenderRunPythonScript( context, blenderFile, pythonScript, environment );
 	}
 
 	private static String showSelectTagSetDialog( ProjectModel projectModel )

--- a/src/main/java/org/mastodon/blender/setup/BlenderSettingsCommand.java
+++ b/src/main/java/org/mastodon/blender/setup/BlenderSettingsCommand.java
@@ -1,14 +1,21 @@
 package org.mastodon.blender.setup;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Objects;
 
+import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
+import org.apache.commons.io.FileUtils;
 import org.scijava.Cancelable;
 import org.scijava.Initializable;
 import org.scijava.command.Command;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
+import org.scijava.widget.Button;
 
 /**
  * This is basically a dialog that allows the user to configure the Blender
@@ -31,11 +38,17 @@ public class BlenderSettingsCommand implements Command, Initializable, Cancelabl
 	@Parameter( label = "Custom *.blend Template", style = "file, extensions:blend", required = false, persist = false, callback = "customInteractiveTemplateChange" )
 	private File interactiveTemplate = null;
 
+	@Parameter( label = "Save Default Template As...", callback = "saveDefaultInteractiveTemplate" )
+	private Button saveDefaultInteractiveTemplate;
+
 	@Parameter( label = "CSV Blender", choices = { DEFAULT, CUSTOM }, style="radioButtonHorizontal", persist = false )
 	private String useCsvTemplate = DEFAULT;
 
 	@Parameter( label = "Custom *.blend Template", style = "file, extensions:blend", required = false, persist = false, callback = "customCsvTemplateChange" )
 	private File csvTemplate = null;
+
+	@Parameter( label = "Save Default Template As...", callback = "saveDefaultCsvTemplate" )
+	private Button saveDefaultCsvTemplate;
 
 	@Override
 	public void initialize()
@@ -102,5 +115,37 @@ public class BlenderSettingsCommand implements Command, Initializable, Cancelabl
 	private void customCsvTemplateChange()
 	{
 		useCsvTemplate = CUSTOM;
+	}
+
+	@SuppressWarnings( "unused" )
+	private void saveDefaultInteractiveTemplate()
+	{
+		saveDefaultTempate( BlenderSettingsService.DEFAULT_INTERACTIVE_TEMPLATE, "Save Default Interactive Template" );
+	}
+
+	@SuppressWarnings( "unused" )
+	private void saveDefaultCsvTemplate()
+	{
+		saveDefaultTempate( BlenderSettingsService.DEFAULT_CSV_TEMPLATE, "Save Default CSV Template" );
+	}
+
+	private static void saveDefaultTempate( URL defaultTemplate, String title )
+	{
+		Objects.requireNonNull( defaultTemplate );
+		JFileChooser fileChooser = new JFileChooser( );
+		fileChooser.setSelectedFile( new File( "template.blend" ) );
+		fileChooser.setDialogTitle( title );
+		fileChooser.setFileFilter( new FileNameExtensionFilter( "Blender File", "blend" ) );
+		boolean ok = fileChooser.showSaveDialog( null ) == JFileChooser.APPROVE_OPTION;
+		if ( !ok )
+			return;
+		try
+		{
+			FileUtils.copyURLToFile( defaultTemplate, fileChooser.getSelectedFile() );
+		}
+		catch ( IOException e )
+		{
+			e.printStackTrace();
+		}
 	}
 }

--- a/src/main/java/org/mastodon/blender/setup/BlenderSettingsCommand.java
+++ b/src/main/java/org/mastodon/blender/setup/BlenderSettingsCommand.java
@@ -1,0 +1,106 @@
+package org.mastodon.blender.setup;
+
+import java.io.File;
+
+import javax.swing.JOptionPane;
+
+import org.scijava.Cancelable;
+import org.scijava.Initializable;
+import org.scijava.command.Command;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+
+/**
+ * This is basically a dialog that allows the user to configure the Blender
+ * templates used by Mastodon.
+ */
+@Plugin( type = Command.class, name = "Configure Blender Templates" )
+public class BlenderSettingsCommand implements Command, Initializable, Cancelable
+{
+
+	@Parameter
+	private BlenderSettingsService blenderSettingsService;
+
+	private static final String DEFAULT = "Use default template";
+
+	private static final String CUSTOM = "Use custom template";
+
+	@Parameter( label = "Interactive Blender", choices = { DEFAULT, CUSTOM }, style="radioButtonHorizontal", persist = false )
+	private String useInteractiveTemple = DEFAULT;
+
+	@Parameter( label = "Custom *.blend Template", style = "file, extensions:blend", required = false, persist = false, callback = "customInteractiveTemplateChange" )
+	private File interactiveTemplate = null;
+
+	@Parameter( label = "CSV Blender", choices = { DEFAULT, CUSTOM }, style="radioButtonHorizontal", persist = false )
+	private String useCsvTemplate = DEFAULT;
+
+	@Parameter( label = "Custom *.blend Template", style = "file, extensions:blend", required = false, persist = false, callback = "customCsvTemplateChange" )
+	private File csvTemplate = null;
+
+	@Override
+	public void initialize()
+	{
+		String interactiveTemplate = blenderSettingsService.getInteractiveBlenderTemplate();
+		String csvTemplate = blenderSettingsService.getCsvBlenderTemplate();
+
+		useInteractiveTemple = interactiveTemplate.isEmpty() ? DEFAULT : CUSTOM;
+		useCsvTemplate = csvTemplate.isEmpty() ? DEFAULT : CUSTOM;
+
+		this.interactiveTemplate = interactiveTemplate.isEmpty() ? null : new File( interactiveTemplate );
+		this.csvTemplate = csvTemplate.isEmpty() ? null : new File( csvTemplate );
+	}
+
+	@Override
+	public void run()
+	{
+		if ( useInteractiveTemple.equals( DEFAULT ) || interactiveTemplate == null )
+			blenderSettingsService.setInteractiveBlenderTemplate( "" );
+		else if ( interactiveTemplate.exists() )
+			blenderSettingsService.setInteractiveBlenderTemplate( interactiveTemplate.getAbsolutePath() );
+		else
+		{
+			blenderSettingsService.setInteractiveBlenderTemplate( "" );
+			JOptionPane.showMessageDialog( null, "Template file does not exist:\n" + csvTemplate, "Error", JOptionPane.ERROR_MESSAGE );
+		}
+
+		if ( useCsvTemplate.equals( DEFAULT ) || csvTemplate == null )
+			blenderSettingsService.setCsvBlenderTemplate( "" );
+		else if ( csvTemplate.exists() )
+			blenderSettingsService.setCsvBlenderTemplate( csvTemplate.getAbsolutePath() );
+		else
+		{
+			blenderSettingsService.setCsvBlenderTemplate( "" );
+			JOptionPane.showMessageDialog( null, "Template file does not exist:\n" + csvTemplate, "Error", JOptionPane.ERROR_MESSAGE );
+		}
+	}
+
+	@Override
+	public boolean isCanceled()
+	{
+		return false;
+	}
+
+	@Override
+	public void cancel( String reason )
+	{
+
+	}
+
+	@Override
+	public String getCancelReason()
+	{
+		return null;
+	}
+
+	@SuppressWarnings( "unused" )
+	private void customInteractiveTemplateChange()
+	{
+		useInteractiveTemple = CUSTOM;
+	}
+
+	@SuppressWarnings( "unused" )
+	private void customCsvTemplateChange()
+	{
+		useCsvTemplate = CUSTOM;
+	}
+}

--- a/src/main/java/org/mastodon/blender/setup/BlenderSettingsService.java
+++ b/src/main/java/org/mastodon/blender/setup/BlenderSettingsService.java
@@ -54,7 +54,7 @@ public class BlenderSettingsService extends AbstractService implements SciJavaSe
 
 	private static File getTemplateCopy( URL defaultResource, String interactiveTemplate ) throws IOException
 	{
-		File tmp = File.createTempFile( "mastodon-bender", ".blend" );
+		File tmp = File.createTempFile( "mastodon-blender", ".blend" );
 		URL source = getUrl( defaultResource, interactiveTemplate );
 		FileUtils.copyURLToFile(source, tmp);
 		return tmp;

--- a/src/main/java/org/mastodon/blender/setup/BlenderSettingsService.java
+++ b/src/main/java/org/mastodon/blender/setup/BlenderSettingsService.java
@@ -19,6 +19,10 @@ import org.scijava.service.SciJavaService;
 public class BlenderSettingsService extends AbstractService implements SciJavaService
 {
 
+	public static final URL DEFAULT_INTERACTIVE_TEMPLATE = BlenderSettingsService.class.getResource( "/blender-scripts/empty.blend" );
+
+	public static final URL DEFAULT_CSV_TEMPLATE = BlenderSettingsService.class.getResource( "/csv/empty_with_geometry_nodes.blend" );
+
 	@Parameter
 	private PrefService prefService;
 
@@ -40,30 +44,29 @@ public class BlenderSettingsService extends AbstractService implements SciJavaSe
 
 	public File getCopyOfInteractiveBlenderTemplate() throws IOException
 	{
-		return getTemplateCopy( "mastodon-bender", "/blender-scripts/empty.blend", getInteractiveBlenderTemplate() );
+		return getTemplateCopy( DEFAULT_INTERACTIVE_TEMPLATE, getInteractiveBlenderTemplate() );
 	}
 
 	public File getCopyOfCsvBlenderTemplate() throws IOException
 	{
-		return getTemplateCopy( "mastodon-bender", "/csv/empty_with_geometry_nodes.blend", getCsvBlenderTemplate() );
+		return getTemplateCopy( DEFAULT_CSV_TEMPLATE, getCsvBlenderTemplate() );
 	}
 
-	private static File getTemplateCopy( String filename, String defaultResource, String interactiveTemplate ) throws IOException
+	private static File getTemplateCopy( URL defaultResource, String interactiveTemplate ) throws IOException
 	{
-		File tmp = File.createTempFile( filename, ".blend" );
+		File tmp = File.createTempFile( "mastodon-bender", ".blend" );
 		URL source = getUrl( defaultResource, interactiveTemplate );
 		FileUtils.copyURLToFile(source, tmp);
 		return tmp;
 	}
 
-	private static URL getUrl( String defaultResource, String interactiveTemplate )
+	private static URL getUrl( URL defaultResource, String interactiveTemplate )
 	{
-		URL defaultTemplate = BlenderSettingsService.class.getResource( defaultResource );
 		if ( interactiveTemplate == null || interactiveTemplate.isEmpty() )
-			return defaultTemplate;
+			return defaultResource;
 		File file = new File( interactiveTemplate );
 		if ( !file.exists() )
-			return defaultTemplate;
+			return defaultResource;
 		try
 		{
 			return file.toURI().toURL();

--- a/src/main/java/org/mastodon/blender/setup/BlenderSettingsService.java
+++ b/src/main/java/org/mastodon/blender/setup/BlenderSettingsService.java
@@ -1,0 +1,76 @@
+package org.mastodon.blender.setup;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.commons.io.FileUtils;
+import org.scijava.plugin.Parameter;
+import org.scijava.plugin.Plugin;
+import org.scijava.prefs.PrefService;
+import org.scijava.service.AbstractService;
+import org.scijava.service.SciJavaService;
+
+/**
+ * A SciJava service that stores the paths to the Blender templates used by Mastodon.
+ */
+@Plugin( type = SciJavaService.class )
+public class BlenderSettingsService extends AbstractService implements SciJavaService
+{
+
+	@Parameter
+	private PrefService prefService;
+
+	public void setInteractiveBlenderTemplate(String template) {
+		prefService.put(BlenderSettingsService.class, "interactiveBlenderTemplate", template);
+	}
+
+	public String getInteractiveBlenderTemplate() {
+		return prefService.get(BlenderSettingsService.class, "interactiveBlenderTemplate", "");
+	}
+
+	public void setCsvBlenderTemplate(String template) {
+		prefService.put(BlenderSettingsService.class, "csvBlenderTemplate", template);
+	}
+
+	public String getCsvBlenderTemplate() {
+		return prefService.get(BlenderSettingsService.class, "csvBlenderTemplate", "");
+	}
+
+	public File getCopyOfInteractiveBlenderTemplate() throws IOException
+	{
+		return getTemplateCopy( "mastodon-bender", "/blender-scripts/empty.blend", getInteractiveBlenderTemplate() );
+	}
+
+	public File getCopyOfCsvBlenderTemplate() throws IOException
+	{
+		return getTemplateCopy( "mastodon-bender", "/csv/empty_with_geometry_nodes.blend", getCsvBlenderTemplate() );
+	}
+
+	private static File getTemplateCopy( String filename, String defaultResource, String interactiveTemplate ) throws IOException
+	{
+		File tmp = File.createTempFile( filename, ".blend" );
+		URL source = getUrl( defaultResource, interactiveTemplate );
+		FileUtils.copyURLToFile(source, tmp);
+		return tmp;
+	}
+
+	private static URL getUrl( String defaultResource, String interactiveTemplate )
+	{
+		URL defaultTemplate = BlenderSettingsService.class.getResource( defaultResource );
+		if ( interactiveTemplate == null || interactiveTemplate.isEmpty() )
+			return defaultTemplate;
+		File file = new File( interactiveTemplate );
+		if ( !file.exists() )
+			return defaultTemplate;
+		try
+		{
+			return file.toURI().toURL();
+		}
+		catch ( MalformedURLException e )
+		{
+			throw new RuntimeException( e );
+		}
+	}
+}

--- a/src/main/java/org/mastodon/blender/setup/BlenderSetupUtils.java
+++ b/src/main/java/org/mastodon/blender/setup/BlenderSetupUtils.java
@@ -99,6 +99,7 @@ public class BlenderSetupUtils
 				+ "time.sleep(8)";
 		int port = StartBlender.getFreePort();
 		Process process = StartBlender.startBlender( blenderPath, //
+				null, //
 				port,
 				"--background", //
 				"--python-expr", script );

--- a/src/main/java/org/mastodon/blender/setup/StartBlender.java
+++ b/src/main/java/org/mastodon/blender/setup/StartBlender.java
@@ -64,15 +64,32 @@ public class StartBlender
 
 	public static void startBlender( Context context, int port ) throws IOException
 	{
-		startBlender( getBlenderPath( context ), port );
+		BlenderSettingsService settingsService = context.service( BlenderSettingsService.class );
+		Path blenderPath = getBlenderPath( context );
+		String blenderTemplate = tryGetTemplate( settingsService );
+		startBlender( blenderPath, blenderTemplate, port );
 	}
 
-	public static Process startBlender( Path blenderPath, int port, String... args )
+	private static String tryGetTemplate( BlenderSettingsService settingsService )
+	{
+		try
+		{
+			return settingsService.getCopyOfInteractiveBlenderTemplate().getAbsolutePath();
+		}
+		catch ( IOException e )
+		{
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	public static Process startBlender( Path blenderPath, String blenderTemplate, int port, String... args )
 			throws IOException
 	{
 		List<String> command = new ArrayList<>();
 		command.add( blenderPath.toString() );
-		command.add( emptyBlenderProject() );
+		if (blenderTemplate != null )
+			command.add( blenderTemplate );
 		command.add( "--addons" );
 		command.add( ADDON_NAME );
 		boolean background = ArrayUtils.contains( args, "--background" )

--- a/src/main/java/org/mastodon/blender/utils/MastodonUtils.java
+++ b/src/main/java/org/mastodon/blender/utils/MastodonUtils.java
@@ -48,6 +48,7 @@ import org.mastodon.model.NavigationListener;
 import org.mastodon.model.TimepointModel;
 import org.mastodon.model.tag.TagSetModel;
 import org.scijava.Context;
+import org.scijava.ui.UIService;
 
 import java.io.IOException;
 
@@ -90,7 +91,9 @@ public class MastodonUtils
 
 	public static ProjectModel showGui(String projectPath) {
 		try {
-			ProjectModel projectModel = ProjectLoader.open( projectPath, new Context(), true, true );
+			Context context = new Context();
+			context.service( UIService.class ).showUI();
+			ProjectModel projectModel = ProjectLoader.open( projectPath, context, true, true );
 			final MainWindow mainWindow = new MainWindow( projectModel );
 			mainWindow.setVisible( true );
 			mainWindow.setDefaultCloseOperation( WindowConstants.EXIT_ON_CLOSE );


### PR DESCRIPTION
There is now a new dialog, that allows the user to specify an empty blender project that will be used when showing the cell tracking data in 3d. A user can save the default template. Make modifications to it, for example: change render settings, add light sources. And then define it to be used a template during executions of "Add Interactive Blender Window" or "Open CSV in Blnder".

![image](https://github.com/mastodon-sc/mastodon-blender-view/assets/24407711/92d09678-0b76-44b6-9bf5-6d87006f5ebd)

![image](https://github.com/mastodon-sc/mastodon-blender-view/assets/24407711/3744dae2-62ac-4969-97f0-f8527db9c70e)
