### PR TITLE
Add feature color modes

### DIFF
--- a/.github/build.sh
+++ b/.github/build.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
+export DISPLAY=:99
+sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
 curl -fsLO https://raw.githubusercontent.com/scijava/scijava-scripts/main/ci-build.sh
 sh ci-build.sh

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,15 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Configure the maven-surefire-plugin to use a heap size of 1gb while running tests. -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.1.0</version>
+				<configuration>
+					<argLine>-Xmx1g</argLine>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<license.excludes>**/zip.xml</license.excludes>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
-		<mastodon.version>1.0.0-beta-28</mastodon.version>
+		<mastodon.version>1.0.0-beta-30</mastodon.version>
 	</properties>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
 			<url>https://github.com/xulman</url>
 			<properties><id>xulman</id></properties>
 		</contributor>
+		<contributor>
+			<name>Stefan Hahmann</name>
+			<url>https://github.com/stefanhahmann</url>
+			<properties>
+				<id>stefanhahmann</id>
+			</properties>
+		</contributor>
 	</contributors>
 
 	<repositories>

--- a/src/main/java/org/mastodon/blender/csv/ColorFunction.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorFunction.java
@@ -1,0 +1,22 @@
+package org.mastodon.blender.csv;
+
+import org.mastodon.mamut.model.Spot;
+
+import java.util.function.Function;
+
+interface ColorFunction extends Function< Spot, Integer >
+{
+	enum Group
+	{
+		TAG_SET,
+		FEATURE_COLOR_MODE
+	}
+
+	Group getGroup();
+
+	default String colorAsString( Spot spot )
+	{
+		Integer color = apply( spot );
+		return color == null ? "" : String.format( "#%06X", ( 0xffffff & color ) );
+	}
+}

--- a/src/main/java/org/mastodon/blender/csv/ColorFunction.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorFunction.java
@@ -1,8 +1,8 @@
 package org.mastodon.blender.csv;
 
-import org.mastodon.mamut.model.Spot;
-
 import java.util.function.Function;
+
+import org.mastodon.mamut.model.Spot;
 
 interface ColorFunction extends Function< Spot, Integer >
 {

--- a/src/main/java/org/mastodon/blender/csv/ColorSchemeChoice.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorSchemeChoice.java
@@ -10,7 +10,9 @@ import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JOptionPane;
-import java.awt.Color;
+import javax.swing.JSeparator;
+import javax.swing.ListCellRenderer;
+
 import java.awt.Component;
 import java.awt.Font;
 import java.util.ArrayList;
@@ -23,13 +25,13 @@ import java.util.stream.Collectors;
  * This class provides can show an option dialog to let the user select a coloring scheme from a list,
  * including tag sets and feature color modes.
  */
-public class ColorSchemeChoice extends JComboBox< String >
+public class ColorSchemeChoice
 {
 	private static final String DEFAULT_OPTION = "[no coloring scheme]";
 
-	private static final String TAGS_HEADER = "Tags";
+	private static final String TAGS_HEADER = "Tags:";
 
-	private static final String FEATURE_COLOR_MODES_HEADER = "Feature Color Modes";
+	private static final String FEATURE_COLOR_MODES_HEADER = "Feature Color Modes:";
 
 	private static final String SEPARATOR = "-----------------";
 
@@ -41,7 +43,7 @@ public class ColorSchemeChoice extends JComboBox< String >
 	 */
 	public static String showDialog( ProjectModel projectModel, ColoringModel coloringModel )
 	{
-		JComboBox< Object > comboBox = getColorSchemesComboBox( projectModel, coloringModel );
+		JComboBox< String > comboBox = getColorSchemesComboBox( projectModel, coloringModel );
 
 		int result = JOptionPane.showOptionDialog(
 				null,
@@ -56,28 +58,27 @@ public class ColorSchemeChoice extends JComboBox< String >
 
 		if ( result == JOptionPane.OK_OPTION )
 		{
-			Object selectedItem = comboBox.getSelectedItem();
-			if ( selectedItem == null )
+			String selectedItem = (String) comboBox.getSelectedItem();
+			if ( selectedItem == null)
 				return null;
-			String option = selectedItem.toString();
-			switch ( option )
+
+			switch ( selectedItem )
 			{
-			case DEFAULT_OPTION:
 			case TAGS_HEADER:
 			case FEATURE_COLOR_MODES_HEADER:
 			case SEPARATOR:
 				return null;
 			default:
-				return option;
+				return selectedItem;
 			}
 		}
 		return null;
 	}
 
-	private static JComboBox< Object > getColorSchemesComboBox( ProjectModel projectModel, ColoringModel coloringModel )
+	private static JComboBox< String > getColorSchemesComboBox( ProjectModel projectModel, ColoringModel coloringModel )
 	{
 		List< String > options = getColorSchemeOptions( projectModel, coloringModel );
-		JComboBox< Object > comboBox = new JComboBox<>( options.toArray() );
+		JComboBox< String > comboBox = new JComboBox<>( options.toArray(new String[0]) );
 		comboBox.setRenderer( new ColorSchemeOptionsRenderer() );
 		return comboBox;
 	}
@@ -100,35 +101,28 @@ public class ColorSchemeChoice extends JComboBox< String >
 		return options;
 	}
 
-	private static class ColorSchemeOptionsRenderer extends DefaultListCellRenderer
+	private static class ColorSchemeOptionsRenderer implements ListCellRenderer< String >
 	{
-		@Override
-		public Component getListCellRendererComponent( JList< ? > list, Object value, int index, boolean isSelected,
-				boolean cellHasFocus )
-		{
-			JLabel renderer = ( JLabel ) super.getListCellRendererComponent( list, value, index, isSelected, cellHasFocus );
-			if ( value instanceof String )
-			{
-				String stringValue = ( String ) value;
 
-				switch ( stringValue )
-				{
-				case TAGS_HEADER:
-				case FEATURE_COLOR_MODES_HEADER:
-					renderer.setFont( renderer.getFont().deriveFont( Font.BOLD ) );
-					renderer.setForeground( Color.BLUE );
-					renderer.setBackground( Color.LIGHT_GRAY );
-					break;
-				case SEPARATOR:
-					renderer.setFont( renderer.getFont().deriveFont( Font.PLAIN ) );
-					renderer.setForeground( Color.GRAY );
-					renderer.setBackground( Color.WHITE );
-					break;
-				default:
-					renderer.setFont( renderer.getFont().deriveFont( Font.PLAIN ) );
-				}
+		private final DefaultListCellRenderer defaultRenderer = new DefaultListCellRenderer();
+
+		@Override
+		public Component getListCellRendererComponent( JList< ? extends String > list, String value, int index, boolean isSelected, boolean cellHasFocus )
+		{
+			switch ( value )
+			{
+			case TAGS_HEADER:
+			case FEATURE_COLOR_MODES_HEADER:
+				JLabel label = ( JLabel ) defaultRenderer.getListCellRendererComponent( list, value, index, false, cellHasFocus );
+				label.setFont( label.getFont().deriveFont( Font.BOLD ) );
+				return label;
+			case SEPARATOR:
+				return new JSeparator( JSeparator.HORIZONTAL );
+			default:
+				JLabel renderer = ( JLabel ) defaultRenderer.getListCellRendererComponent( list, value, index, isSelected, cellHasFocus );
+				renderer.setFont( renderer.getFont().deriveFont( Font.PLAIN ) );
+				return renderer;
 			}
-			return renderer;
 		}
 	}
 }

--- a/src/main/java/org/mastodon/blender/csv/ColorSchemeChoice.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorSchemeChoice.java
@@ -1,0 +1,134 @@
+package org.mastodon.blender.csv;
+
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.model.tag.TagSetStructure;
+import org.mastodon.ui.coloring.ColoringModel;
+import org.mastodon.ui.coloring.feature.FeatureColorMode;
+
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JOptionPane;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Font;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A JComboBox for selecting a color scheme.
+ * <br>
+ * This class provides can show an option dialog to let the user select a coloring scheme from a list,
+ * including tag sets and feature color modes.
+ */
+public class ColorSchemeChoice extends JComboBox< String >
+{
+	private static final String DEFAULT_OPTION = "[no coloring scheme]";
+
+	private static final String TAGS_HEADER = "Tags";
+
+	private static final String FEATURE_COLOR_MODES_HEADER = "Feature Color Modes";
+
+	private static final String SEPARATOR = "-----------------";
+
+	/**
+	 * Show a dialog to let the user select a coloring scheme.
+	 * @param projectModel the project model
+	 * @param coloringModel the coloring model
+	 * @return the name of the selected coloring scheme, or {@code null} if none was selected.
+	 */
+	public static String showDialog( ProjectModel projectModel, ColoringModel coloringModel )
+	{
+		JComboBox< Object > comboBox = getColorSchemesComboBox( projectModel, coloringModel );
+
+		int result = JOptionPane.showOptionDialog(
+				null,
+				comboBox,
+				"Select coloring scheme",
+				JOptionPane.OK_CANCEL_OPTION,
+				JOptionPane.PLAIN_MESSAGE,
+				null,
+				null,
+				DEFAULT_OPTION
+		);
+
+		if ( result == JOptionPane.OK_OPTION )
+		{
+			Object selectedItem = comboBox.getSelectedItem();
+			if ( selectedItem == null )
+				return null;
+			String option = selectedItem.toString();
+			switch ( option )
+			{
+			case DEFAULT_OPTION:
+			case TAGS_HEADER:
+			case FEATURE_COLOR_MODES_HEADER:
+			case SEPARATOR:
+				return null;
+			default:
+				return option;
+			}
+		}
+		return null;
+	}
+
+	private static JComboBox< Object > getColorSchemesComboBox( ProjectModel projectModel, ColoringModel coloringModel )
+	{
+		List< String > options = getColorSchemeOptions( projectModel, coloringModel );
+		JComboBox< Object > comboBox = new JComboBox<>( options.toArray() );
+		comboBox.setRenderer( new ColorSchemeOptionsRenderer() );
+		return comboBox;
+	}
+
+	static List< String > getColorSchemeOptions( ProjectModel projectModel, ColoringModel coloringModel )
+	{
+		List< String > tagSets = projectModel.getModel().getTagSetModel().getTagSetStructure().getTagSets().stream()
+				.map( TagSetStructure.TagSet::getName ).collect( Collectors.toList() );
+		List< String > featureColorModes =
+				GraphToCsvUtils.getValidFeatureColorModes( coloringModel ).stream().map( FeatureColorMode::getName )
+						.collect( Collectors.toList() );
+		List< String > options = new ArrayList<>();
+		options.add( DEFAULT_OPTION );
+		options.add( SEPARATOR );
+		options.add( TAGS_HEADER );
+		options.addAll( tagSets );
+		options.add( SEPARATOR );
+		options.add( FEATURE_COLOR_MODES_HEADER );
+		options.addAll( featureColorModes );
+		return options;
+	}
+
+	private static class ColorSchemeOptionsRenderer extends DefaultListCellRenderer
+	{
+		@Override
+		public Component getListCellRendererComponent( JList< ? > list, Object value, int index, boolean isSelected,
+				boolean cellHasFocus )
+		{
+			JLabel renderer = ( JLabel ) super.getListCellRendererComponent( list, value, index, isSelected, cellHasFocus );
+			if ( value instanceof String )
+			{
+				String stringValue = ( String ) value;
+
+				switch ( stringValue )
+				{
+				case TAGS_HEADER:
+				case FEATURE_COLOR_MODES_HEADER:
+					renderer.setFont( renderer.getFont().deriveFont( Font.BOLD ) );
+					renderer.setForeground( Color.BLUE );
+					renderer.setBackground( Color.LIGHT_GRAY );
+					break;
+				case SEPARATOR:
+					renderer.setFont( renderer.getFont().deriveFont( Font.PLAIN ) );
+					renderer.setForeground( Color.GRAY );
+					renderer.setBackground( Color.WHITE );
+					break;
+				default:
+					renderer.setFont( renderer.getFont().deriveFont( Font.PLAIN ) );
+				}
+			}
+			return renderer;
+		}
+	}
+}

--- a/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
@@ -113,7 +113,7 @@ public class ColorSchemeDialog
 				case SEPARATOR:
 					return new JSeparator( SwingConstants.HORIZONTAL );
 				default:
-					return new JLabel( colorFunction.toString() );
+					// use default renderer
 				}
 			}
 			JLabel renderer =

--- a/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
@@ -100,7 +100,7 @@ public class ColorSchemeDialog
 		public Component getListCellRendererComponent( final JList< ? extends ColorFunction > list, final ColorFunction colorFunction,
 				final int index, final boolean isSelected, final boolean cellHasFocus )
 		{
-			if ( colorFunction instanceof EmptyColorFuntion )
+			if ( colorFunction instanceof EmptyColorFunction )
 			{
 				String name = colorFunction.toString();
 				switch ( name )
@@ -114,13 +114,13 @@ public class ColorSchemeDialog
 				case SEPARATOR:
 					return new JSeparator( SwingConstants.HORIZONTAL );
 				default:
-					// use default renderer
+					// use default entry rendering
 				}
 			}
-			JLabel renderer =
+			JLabel defaultEntry =
 					( JLabel ) defaultRenderer.getListCellRendererComponent( list, colorFunction, index, isSelected, cellHasFocus );
-			renderer.setFont( renderer.getFont().deriveFont( Font.PLAIN ) );
-			return renderer;
+			defaultEntry.setFont( defaultEntry.getFont().deriveFont( Font.PLAIN ) );
+			return defaultEntry;
 		}
 	}
 

--- a/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
@@ -1,7 +1,9 @@
 package org.mastodon.blender.csv;
 
-import org.mastodon.mamut.ProjectModel;
-import org.mastodon.mamut.model.Spot;
+import java.awt.Component;
+import java.awt.Font;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JComboBox;
@@ -11,10 +13,9 @@ import javax.swing.JOptionPane;
 import javax.swing.JSeparator;
 import javax.swing.ListCellRenderer;
 import javax.swing.SwingConstants;
-import java.awt.Component;
-import java.awt.Font;
-import java.util.ArrayList;
-import java.util.List;
+
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.model.Spot;
 
 /**
  * A JComboBox for selecting a color scheme.

--- a/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
@@ -130,4 +130,32 @@ public class ColorSchemeDialog
 			}
 		}
 	}
+
+	private static class EmptyColorFunction implements ColorFunction
+	{
+		private final String name;
+
+		private EmptyColorFunction( String name )
+		{
+			this.name = name;
+		}
+
+		@Override
+		public String toString()
+		{
+			return name;
+		}
+
+		@Override
+		public Group getGroup()
+		{
+			return null;
+		}
+
+		@Override
+		public Integer apply( final Spot spot )
+		{
+			return null;
+		}
+	}
 }

--- a/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
@@ -99,7 +99,7 @@ public class ColorSchemeDialog
 		public Component getListCellRendererComponent( final JList< ? extends ColorFunction > list, final ColorFunction colorFunction,
 				final int index, final boolean isSelected, final boolean cellHasFocus )
 		{
-			if ( colorFunction.getGroup() == null )
+			if ( colorFunction instanceof EmptyColorFuntion )
 			{
 				String name = colorFunction.toString();
 				switch ( name )

--- a/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
+++ b/src/main/java/org/mastodon/blender/csv/ColorSchemeDialog.java
@@ -25,8 +25,13 @@ import java.util.stream.Collectors;
  * This class provides can show an option dialog to let the user select a coloring scheme from a list,
  * including tag sets and feature color modes.
  */
-public class ColorSchemeChoice
+public class ColorSchemeDialog
 {
+	private ColorSchemeDialog()
+	{
+		// prevent instantiation
+	}
+
 	private static final String DEFAULT_OPTION = "[no coloring scheme]";
 
 	private static final String TAGS_HEADER = "Tags:";

--- a/src/main/java/org/mastodon/blender/csv/ExportGraphAsCsvAction.java
+++ b/src/main/java/org/mastodon/blender/csv/ExportGraphAsCsvAction.java
@@ -46,7 +46,7 @@ public class ExportGraphAsCsvAction
 		boolean isCancelled = filename == null;
 		if ( isCancelled )
 			return;
-		GraphToCsvUtils.writeCsv( projectModel.getModel(), filename );
+		GraphToCsvUtils.writeCsv( projectModel, filename );
 	}
 
 	private static String saveCsvFileDialog( String defaultFile )

--- a/src/main/java/org/mastodon/blender/csv/FeatureColorFunction.java
+++ b/src/main/java/org/mastodon/blender/csv/FeatureColorFunction.java
@@ -1,0 +1,42 @@
+package org.mastodon.blender.csv;
+
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.model.branch.BranchLink;
+import org.mastodon.mamut.model.branch.BranchSpot;
+import org.mastodon.ui.coloring.ColoringModelMain;
+import org.mastodon.ui.coloring.GraphColorGenerator;
+import org.mastodon.ui.coloring.feature.FeatureColorMode;
+
+class FeatureColorFunction implements ColorFunction
+{
+	private final GraphColorGenerator< Spot, Link > colorGenerator;
+
+	private final String name;
+
+	FeatureColorFunction( ColoringModelMain< Spot, Link, BranchSpot, BranchLink > coloringModel,
+			FeatureColorMode featureColorMode )
+	{
+		coloringModel.colorByFeature( featureColorMode );
+		colorGenerator = coloringModel.getFeatureGraphColorGenerator();
+		name = featureColorMode.getName();
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+
+	@Override
+	public Group getGroup()
+	{
+		return Group.FEATURE_COLOR_MODE;
+	}
+
+	@Override
+	public Integer apply( final Spot spot )
+	{
+		return colorGenerator.color( spot );
+	}
+}

--- a/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
+++ b/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
@@ -95,6 +95,14 @@ public class GraphToCsvUtils
 		writeCsv( model, filename, null );
 	}
 
+	/**
+	 * Write the specified {@link Model} to the specified CSV file.
+	 */
+	public static void writeCsv( ProjectModel projectModel, String filename )
+	{
+		writeCsv( projectModel.getModel(), filename, createColoringModel( projectModel ) );
+	}
+
 	private static void writeHeader( BufferedWriter writer, List< TagSetStructure.TagSet > tagSets, List< FeatureColorMode > colorModes )
 			throws IOException
 	{

--- a/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
+++ b/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
@@ -28,20 +28,25 @@
  */
 package org.mastodon.blender.csv;
 
+import org.mastodon.graph.ref.IncomingEdges;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.model.Link;
+import org.mastodon.mamut.model.Model;
+import org.mastodon.mamut.model.ModelGraph;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.model.branch.BranchLink;
+import org.mastodon.mamut.model.branch.BranchSpot;
+import org.mastodon.model.tag.ObjTagMap;
+import org.mastodon.model.tag.TagSetStructure;
+import org.mastodon.ui.coloring.ColoringModelMain;
+import org.mastodon.ui.coloring.feature.FeatureColorModeManager;
+
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
-
-import org.mastodon.graph.ref.IncomingEdges;
-import org.mastodon.mamut.model.Link;
-import org.mastodon.mamut.model.Model;
-import org.mastodon.mamut.model.ModelGraph;
-import org.mastodon.mamut.model.Spot;
-import org.mastodon.model.tag.ObjTagMap;
-import org.mastodon.model.tag.TagSetStructure;
 
 /**
  * Utility class to export a {@link Model} to a CSV file.
@@ -129,5 +134,13 @@ public class GraphToCsvUtils
 	private static String colorAsString( int color )
 	{
 		return String.format( "#%06X", ( 0xffffff & color ) );
+	}
+
+	static ColoringModelMain< Spot, Link, BranchSpot, BranchLink > createColoringModel( ProjectModel projectModel )
+	{
+		final FeatureColorModeManager featureColorModeManager = projectModel.getWindowManager().getManager( FeatureColorModeManager.class );
+		final Model model = projectModel.getModel();
+		return new ColoringModelMain<>( model.getTagSetModel(), featureColorModeManager, model.getFeatureModel(),
+				model.getBranchGraph() );
 	}
 }

--- a/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
+++ b/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
@@ -38,12 +38,16 @@ import org.mastodon.mamut.model.branch.BranchLink;
 import org.mastodon.mamut.model.branch.BranchSpot;
 import org.mastodon.model.tag.ObjTagMap;
 import org.mastodon.model.tag.TagSetStructure;
+import org.mastodon.ui.coloring.ColoringModel;
 import org.mastodon.ui.coloring.ColoringModelMain;
+import org.mastodon.ui.coloring.feature.FeatureColorMode;
 import org.mastodon.ui.coloring.feature.FeatureColorModeManager;
 
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
@@ -142,5 +146,19 @@ public class GraphToCsvUtils
 		final Model model = projectModel.getModel();
 		return new ColoringModelMain<>( model.getTagSetModel(), featureColorModeManager, model.getFeatureModel(),
 				model.getBranchGraph() );
+	}
+
+	static List< FeatureColorMode > getValidFeatureColorModes( ColoringModel coloringModel )
+	{
+		if ( coloringModel == null )
+			return Collections.emptyList();
+		FeatureColorModeManager colorModeManager = coloringModel.getFeatureColorModeManager();
+		if ( colorModeManager == null )
+			return Collections.emptyList();
+		List< FeatureColorMode > colorModes = new ArrayList<>();
+		colorModes.addAll( colorModeManager.getUserStyles() );
+		colorModes.addAll( colorModeManager.getBuiltinStyles() );
+		colorModes.removeIf( colorMode -> !coloringModel.isValid( colorMode ) );
+		return colorModes;
 	}
 }

--- a/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
+++ b/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
@@ -127,7 +127,7 @@ public class GraphToCsvUtils
 	}
 
 
-	static ColoringModelMain< Spot, Link, BranchSpot, BranchLink > createColoringModel( ProjectModel projectModel )
+	private static ColoringModelMain< Spot, Link, BranchSpot, BranchLink > createColoringModel( ProjectModel projectModel )
 	{
 		final FeatureColorModeManager featureColorModeManager = projectModel.getWindowManager().getManager( FeatureColorModeManager.class );
 		final Model model = projectModel.getModel();
@@ -135,7 +135,7 @@ public class GraphToCsvUtils
 				model.getBranchGraph() );
 	}
 
-	static List< ColorFunction > getColorFunctions( ProjectModel projectModel )
+	private static List< ColorFunction > getColorFunctions( ProjectModel projectModel )
 	{
 		List< ColorFunction > colorFunctions = getTagSetColorFunctions( projectModel );
 		colorFunctions.addAll( getFeatureColorFunctions( projectModel ) );

--- a/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
+++ b/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
@@ -36,9 +36,7 @@ import org.mastodon.mamut.model.ModelGraph;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.mamut.model.branch.BranchLink;
 import org.mastodon.mamut.model.branch.BranchSpot;
-import org.mastodon.model.tag.ObjTagMap;
-import org.mastodon.model.tag.TagSetStructure;
-import org.mastodon.ui.coloring.ColoringModel;
+import org.mastodon.model.tag.TagSetModel;
 import org.mastodon.ui.coloring.ColoringModelMain;
 import org.mastodon.ui.coloring.GraphColorGenerator;
 import org.mastodon.ui.coloring.feature.FeatureColorMode;
@@ -190,5 +188,26 @@ public class GraphToCsvUtils
 		colorModes.addAll( colorModeManager.getBuiltinStyles() );
 		colorModes.removeIf( colorMode -> !coloringModel.isValid( colorMode ) );
 		return colorModes;
+	}
+
+	static List< ColorFunction > getTagSetColorFunctions( ProjectModel projectModel )
+	{
+		TagSetModel< Spot, Link > tagSetModel = projectModel.getModel().getTagSetModel();
+		return tagSetModel.getTagSetStructure().getTagSets().stream()
+				.map( tagSet -> new TagSetColorFunction( tagSet, tagSetModel.getVertexTags().tags( tagSet ) ) )
+				.collect( Collectors.toList() );
+
+	}
+
+	static List< ColorFunction > getFeatureColorFunctions( ProjectModel projectModel )
+	{
+		ColoringModelMain< Spot, Link, BranchSpot, BranchLink > coloringModel = createColoringModel( projectModel );
+		FeatureColorModeManager colorModeManager = coloringModel.getFeatureColorModeManager();
+		List< FeatureColorMode > colorModes = new ArrayList<>();
+		colorModes.addAll( colorModeManager.getUserStyles() );
+		colorModes.addAll( colorModeManager.getBuiltinStyles() );
+		return colorModes.stream().filter( coloringModel::isValid )
+				.map( colorMode -> new FeatureColorFunction( coloringModel, colorMode ) )
+				.collect( Collectors.toList() );
 	}
 }

--- a/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
+++ b/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
@@ -123,6 +123,11 @@ public class GraphToCsvUtils
 	{
 		if ( tag == null )
 			return "";
-		return String.format( "#%06X", ( 0xffffff & tag.color() ) );
+		return colorAsString( tag.color() );
+	}
+
+	private static String colorAsString( int color )
+	{
+		return String.format( "#%06X", ( 0xffffff & color ) );
 	}
 }

--- a/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
+++ b/src/main/java/org/mastodon/blender/csv/GraphToCsvUtils.java
@@ -28,6 +28,14 @@
  */
 package org.mastodon.blender.csv;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
+
 import org.mastodon.graph.ref.IncomingEdges;
 import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.model.Link;
@@ -40,14 +48,6 @@ import org.mastodon.model.tag.TagSetModel;
 import org.mastodon.ui.coloring.ColoringModelMain;
 import org.mastodon.ui.coloring.feature.FeatureColorMode;
 import org.mastodon.ui.coloring.feature.FeatureColorModeManager;
-
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 
 /**
  * Utility class to export a {@link Model} to a CSV file.

--- a/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
+++ b/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
@@ -28,6 +28,14 @@
  */
 package org.mastodon.blender.csv;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.mastodon.blender.setup.BlenderSettingsService;
@@ -36,14 +44,6 @@ import org.mastodon.blender.setup.StartBlender;
 import org.mastodon.mamut.ProjectModel;
 import org.mastodon.mamut.model.Model;
 import org.scijava.Context;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * Export the Mastodon graph as CSV file such that it can be opened with Blender.

--- a/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
+++ b/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
@@ -28,6 +28,15 @@
  */
 package org.mastodon.blender.csv;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.mastodon.blender.setup.BlenderSettingsService;
+import org.mastodon.blender.setup.BlenderSetup;
+import org.mastodon.blender.setup.StartBlender;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.model.Model;
+import org.scijava.Context;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -35,20 +44,6 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
-import org.mastodon.blender.setup.BlenderSettingsService;
-import org.mastodon.blender.setup.BlenderSetup;
-import org.mastodon.blender.setup.StartBlender;
-import org.mastodon.mamut.ProjectModel;
-import org.mastodon.mamut.model.Link;
-import org.mastodon.mamut.model.Model;
-import org.mastodon.mamut.model.Spot;
-import org.mastodon.mamut.model.branch.BranchLink;
-import org.mastodon.mamut.model.branch.BranchSpot;
-import org.mastodon.ui.coloring.ColoringModelMain;
-import org.scijava.Context;
 
 /**
  * Export the Mastodon graph as CSV file such that it can be opened with Blender.
@@ -58,14 +53,13 @@ public class StartBlenderWithCsvAction
 
 	public static void run(ProjectModel projectModel)
 	{
-		ColoringModelMain< Spot, Link, BranchSpot, BranchLink > coloringModel = GraphToCsvUtils.createColoringModel( projectModel );
-		String selectedColorScheme = ColorSchemeDialog.showDialog( projectModel, coloringModel );
+		String selectedColorScheme = ColorSchemeDialog.showDialog( projectModel );
 		if ( selectedColorScheme == null )
 			return;
 		new Thread(() -> {
 			try
 			{
-				String csv = createCsv( projectModel, coloringModel );
+				String csv = createCsv( projectModel );
 				try
 				{
 					startBlenderWithCsv( projectModel, selectedColorScheme, csv );
@@ -82,8 +76,7 @@ public class StartBlenderWithCsvAction
 		}).start();
 	}
 
-	private static String createCsv( ProjectModel projectModel, ColoringModelMain< Spot, Link, BranchSpot, BranchLink > coloringModel )
-			throws IOException
+	private static String createCsv( ProjectModel projectModel ) throws IOException
 	{
 		String csv = Files.createTempFile( "mastodon-graph", ".csv" ).toFile().getAbsolutePath();
 		Model model = projectModel.getModel();
@@ -91,7 +84,7 @@ public class StartBlenderWithCsvAction
 		lock.readLock().lock();
 		try
 		{
-			GraphToCsvUtils.writeCsv( projectModel.getModel(), csv, coloringModel );
+			GraphToCsvUtils.writeCsv( projectModel, csv );
 		}
 		finally
 		{

--- a/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
+++ b/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
@@ -33,22 +33,21 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
-
-import javax.swing.JOptionPane;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
-import org.mastodon.blender.StartBlenderException;
 import org.mastodon.blender.setup.BlenderSettingsService;
 import org.mastodon.blender.setup.BlenderSetup;
 import org.mastodon.blender.setup.StartBlender;
 import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.model.Link;
 import org.mastodon.mamut.model.Model;
-import org.mastodon.model.tag.TagSetStructure;
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.mamut.model.branch.BranchLink;
+import org.mastodon.mamut.model.branch.BranchSpot;
+import org.mastodon.ui.coloring.ColoringModelMain;
 import org.scijava.Context;
 
 /**
@@ -59,16 +58,17 @@ public class StartBlenderWithCsvAction
 
 	public static void run(ProjectModel projectModel)
 	{
-		String tagset = showSelectTagSetDialog( projectModel );
-		if ( tagset == null )
+		ColoringModelMain< Spot, Link, BranchSpot, BranchLink > coloringModel = GraphToCsvUtils.createColoringModel( projectModel );
+		String selectedColorScheme = ColorSchemeChoice.showDialog( projectModel, coloringModel );
+		if ( selectedColorScheme == null )
 			return;
 		new Thread(() -> {
 			try
 			{
-				String csv = createCsv( projectModel );
+				String csv = createCsv( projectModel, coloringModel );
 				try
 				{
-					startBlenderWithCsv( projectModel, tagset, csv );
+					startBlenderWithCsv( projectModel, selectedColorScheme, csv );
 				}
 				catch ( Exception e )
 				{
@@ -82,7 +82,8 @@ public class StartBlenderWithCsvAction
 		}).start();
 	}
 
-	private static String createCsv( ProjectModel projectModel ) throws IOException
+	private static String createCsv( ProjectModel projectModel, ColoringModelMain< Spot, Link, BranchSpot, BranchLink > coloringModel )
+			throws IOException
 	{
 		String csv = Files.createTempFile( "mastodon-graph", ".csv" ).toFile().getAbsolutePath();
 		Model model = projectModel.getModel();
@@ -90,7 +91,7 @@ public class StartBlenderWithCsvAction
 		lock.readLock().lock();
 		try
 		{
-			GraphToCsvUtils.writeCsv( model, csv );
+			GraphToCsvUtils.writeCsv( projectModel.getModel(), csv, coloringModel );
 		}
 		finally
 		{
@@ -109,15 +110,6 @@ public class StartBlenderWithCsvAction
 		environment.put( "MASTODON_BLENDER_CSV_FILE", csv );
 		environment.put( "MASTODON_BLENDER_TAG_SET", tagset );
 		StartBlender.startBlenderRunPythonScript( context, blenderFile, pythonScript, environment );
-	}
-
-	private static String showSelectTagSetDialog( ProjectModel projectModel )
-	{
-		List< String > tagSets = projectModel.getModel().getTagSetModel().getTagSetStructure().getTagSets().stream().map( TagSetStructure.TagSet::getName ).collect( Collectors.toList() );
-		tagSets.add( 0, "[no tag set]" );
-		Object result = JOptionPane.showInputDialog( null, "Please select a tag set for visualization", "Blender Using Geometry Nodes",
-				JOptionPane.PLAIN_MESSAGE, null, tagSets.toArray(), tagSets.get( 0 ) );
-		return (String) result;
 	}
 
 	private static String copyResource( String resourceName ) throws IOException

--- a/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
+++ b/src/main/java/org/mastodon/blender/csv/StartBlenderWithCsvAction.java
@@ -59,7 +59,7 @@ public class StartBlenderWithCsvAction
 	public static void run(ProjectModel projectModel)
 	{
 		ColoringModelMain< Spot, Link, BranchSpot, BranchLink > coloringModel = GraphToCsvUtils.createColoringModel( projectModel );
-		String selectedColorScheme = ColorSchemeChoice.showDialog( projectModel, coloringModel );
+		String selectedColorScheme = ColorSchemeDialog.showDialog( projectModel, coloringModel );
 		if ( selectedColorScheme == null )
 			return;
 		new Thread(() -> {

--- a/src/main/java/org/mastodon/blender/csv/TagSetColorFunction.java
+++ b/src/main/java/org/mastodon/blender/csv/TagSetColorFunction.java
@@ -1,0 +1,37 @@
+package org.mastodon.blender.csv;
+
+import org.mastodon.mamut.model.Spot;
+import org.mastodon.model.tag.ObjTagMap;
+import org.mastodon.model.tag.TagSetStructure;
+
+class TagSetColorFunction implements ColorFunction
+{
+	private final TagSetStructure.TagSet tagSet;
+
+	private final ObjTagMap< Spot, TagSetStructure.Tag > tagMap;
+
+	TagSetColorFunction( TagSetStructure.TagSet tagSet, ObjTagMap< Spot, TagSetStructure.Tag > tagMap )
+	{
+		this.tagSet = tagSet;
+		this.tagMap = tagMap;
+	}
+
+	@Override
+	public String toString()
+	{
+		return tagSet.getName();
+	}
+
+	@Override
+	public Group getGroup()
+	{
+		return Group.TAG_SET;
+	}
+
+	@Override
+	public Integer apply( final Spot spot )
+	{
+		TagSetStructure.Tag tag = tagMap.get( spot );
+		return tag == null ? null : tag.color();
+	}
+}

--- a/src/test/java/org/mastodon/blender/csv/GraphToCsvUtilsTest.java
+++ b/src/test/java/org/mastodon/blender/csv/GraphToCsvUtilsTest.java
@@ -29,9 +29,10 @@ public class GraphToCsvUtilsTest
 		GraphToCsvUtils.writeCsv( model, csvFile.getAbsolutePath() );
 		// test
 		String content = FileUtils.readFileToString( csvFile, StandardCharsets.UTF_8 );
-		String expected = "id, label, timepoint, x, y, z, radius, parent_id, \"tagset, with comma, and \"\"double quotes\"\"\"\n"
-				+ "0, \"spotA\", 0, 1.0, 2.0, 3.0, 1.0, , #AABBCC\n"
-				+ "1, \"spot,B\", 1, 3.0, 3.0, 4.0, 2.0, , #112233\n";
+		String newLine = System.lineSeparator();
+		String expected = "id, label, timepoint, x, y, z, radius, parent_id, \"tagset, with comma, and \"\"double quotes\"\"\"" + newLine
+				+ "0, \"spotA\", 0, 1.0, 2.0, 3.0, 1.0, , #AABBCC" + newLine
+				+ "1, \"spot,B\", 1, 3.0, 3.0, 4.0, 2.0, , #112233" + newLine;
 		assertEquals( expected, content );
 	}
 

--- a/src/test/java/org/mastodon/blender/csv/GraphToCsvUtilsTest.java
+++ b/src/test/java/org/mastodon/blender/csv/GraphToCsvUtilsTest.java
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
 
-import ij.ImagePlus;
 import net.imagej.ImgPlus;
 import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
@@ -16,6 +15,7 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.img.display.imagej.ImgToVirtualStack;
 import net.imglib2.type.numeric.real.FloatType;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
@@ -29,6 +29,8 @@ import org.mastodon.util.TagHelper;
 import org.mastodon.util.TagSetUtils;
 import org.mastodon.views.bdv.SharedBigDataViewerData;
 import org.scijava.Context;
+
+import ij.ImagePlus;
 
 public class GraphToCsvUtilsTest
 {

--- a/src/test/java/org/mastodon/blender/csv/GraphToCsvUtilsTest.java
+++ b/src/test/java/org/mastodon/blender/csv/GraphToCsvUtilsTest.java
@@ -6,16 +6,29 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Objects;
 
+import ij.ImagePlus;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.display.imagej.ImgToVirtualStack;
+import net.imglib2.type.numeric.real.FloatType;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
+import org.mastodon.mamut.ProjectModel;
+import org.mastodon.mamut.io.project.MamutProject;
 import org.mastodon.mamut.model.Model;
 import org.mastodon.mamut.model.ModelGraph;
 import org.mastodon.mamut.model.Spot;
 import org.mastodon.model.tag.TagSetStructure;
 import org.mastodon.util.TagHelper;
 import org.mastodon.util.TagSetUtils;
+import org.mastodon.views.bdv.SharedBigDataViewerData;
+import org.scijava.Context;
 
 public class GraphToCsvUtilsTest
 {
@@ -24,16 +37,25 @@ public class GraphToCsvUtilsTest
 	{
 		// setup
 		Model model = initializeExampleModel();
-		File csvFile = File.createTempFile( "mastodon-graph", ".csv" );
-		// process
-		GraphToCsvUtils.writeCsv( model, csvFile.getAbsolutePath() );
-		// test
-		String content = FileUtils.readFileToString( csvFile, StandardCharsets.UTF_8 );
-		String newLine = System.lineSeparator();
-		String expected = "id, label, timepoint, x, y, z, radius, parent_id, \"tagset, with comma, and \"\"double quotes\"\"\"" + newLine
-				+ "0, \"spotA\", 0, 1.0, 2.0, 3.0, 1.0, , #AABBCC" + newLine
-				+ "1, \"spot,B\", 1, 3.0, 3.0, 4.0, 2.0, , #112233" + newLine;
-		assertEquals( expected, content );
+		File mastodonFile = File.createTempFile( "test", ".mastodon" );
+		Img< FloatType > image = ArrayImgs.floats( 1, 1, 1 );
+		try (Context context = new Context())
+		{
+			ProjectModel projectModel = wrapAsAppModel( image, model, context, mastodonFile );
+			File csvFile = File.createTempFile( "mastodon-graph", ".csv" );
+			// process
+			GraphToCsvUtils.writeCsv( projectModel, csvFile.getAbsolutePath() );
+			// test
+			String content = FileUtils.readFileToString( csvFile, StandardCharsets.UTF_8 );
+			String newLine = System.lineSeparator();
+			String expected =
+					"id, label, timepoint, x, y, z, radius, parent_id, \"tagset, with comma, and \"\"double quotes\"\"\", \"Number of links\""
+							+ newLine
+							+ "0, \"spotA\", 0, 1.0, 2.0, 3.0, 1.0, , #AABBCC, #352A87" + newLine
+							+ "1, \"spot,B\", 1, 3.0, 3.0, 4.0, 2.0, , #112233, #352A87" + newLine;
+			assertEquals( expected, content );
+		}
+
 	}
 
 	private static Model initializeExampleModel()
@@ -53,5 +75,24 @@ public class GraphToCsvUtilsTest
 		a.tagSpot( spotA );
 		b.tagSpot( spotB );
 		return model;
+	}
+
+	// TODO: can be removed after https://github.com/mastodon-sc/mastodon/pull/325/ is merged and beta-31 is released
+	private static ProjectModel wrapAsAppModel( final Img< FloatType > image, final Model model, final Context context, final File file )
+			throws IOException
+	{
+		final SharedBigDataViewerData sharedBigDataViewerData = asSharedBdvDataXyz( image );
+		MamutProject mamutProject = new MamutProject( file );
+		File datasetXmlFile = File.createTempFile( "test", ".xml" );
+		mamutProject.setDatasetXmlFile( datasetXmlFile );
+		return ProjectModel.create( context, model, sharedBigDataViewerData, mamutProject );
+	}
+
+	// TODO: can be removed after https://github.com/mastodon-sc/mastodon/pull/325/ is merged and beta-31 is released
+	private static SharedBigDataViewerData asSharedBdvDataXyz( final Img< FloatType > image1 )
+	{
+		final ImagePlus image =
+				ImgToVirtualStack.wrap( new ImgPlus<>( image1, "image", new AxisType[] { Axes.X, Axes.Y, Axes.Z, Axes.TIME } ) );
+		return Objects.requireNonNull( SharedBigDataViewerData.fromImagePlus( image ) );
 	}
 }


### PR DESCRIPTION
Besides TagSets users of the Mastodon Blender View wanted to be able to use Feature Color Modes that can be created in the preferences of Mastodon to color the spots in the Mastodon Blender View.

![grafik](https://github.com/user-attachments/assets/99be0802-23c8-42cf-b543-c858683aa5dc)

This PR adds the possibility to do so. When starting a new `Geometry Nodes Blender Window`, the user can now select tag sets (as was possible already) and valid feature color modes to color the spots in the Blender View:

![grafik](https://github.com/user-attachments/assets/e1fda07d-3277-492f-b1bc-ead0f248f969)

All feature color modes are added as columns to the exported CSV. The selected tag set or feature color is used for coloring the spots in the Blender View:

![GIF 09 09 2024 18-33-16](https://github.com/user-attachments/assets/c797cf66-8ed4-4909-a404-057bcc0faadc)

The feature color modes are also added to the exported CSV in the `Export CSV for Blender` action:

![grafik](https://github.com/user-attachments/assets/84f606a2-8cf6-4e0d-9c09-8bbb63eb2c88)

Resolves: https://github.com/mastodon-sc/mastodon-blender-view/issues/23