### PR TITLE
Improve Error Dialog & Increase Timeout for Starting Blender

### DIFF
--- a/src/main/java/org/mastodon/blender/ViewServiceClient.java
+++ b/src/main/java/org/mastodon/blender/ViewServiceClient.java
@@ -83,7 +83,7 @@ public class ViewServiceClient
 			String version = ViewServiceGrpc
 					.newBlockingStub( channel )
 					.withWaitForReady()
-					.withDeadlineAfter( 10, TimeUnit.SECONDS )
+					.withDeadlineAfter( 20, TimeUnit.SECONDS )
 					.getVersion( Empty.newBuilder().build() )
 					.getVersion();
 			if ( !version.equals( "0.1.0" ) )

--- a/src/main/java/org/mastodon/blender/utils/ExceptionDialog.java
+++ b/src/main/java/org/mastodon/blender/utils/ExceptionDialog.java
@@ -47,6 +47,8 @@ import java.awt.event.MouseEvent;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 public class ExceptionDialog
 {
 
@@ -75,7 +77,10 @@ public class ExceptionDialog
 		final JScrollPane scrollPane = initScrollPane( textArea );
 		final JLabel showDetailsLabel = initShowDetailsLabel( scrollPane );
 		JPanel panel = new JPanel(new MigLayout("insets dialog", "[grow]", "[][][grow]"));
-		panel.add(new JLabel( message ), "wrap");
+		String messageHtml = "<html><body>"
+				+ StringEscapeUtils.escapeHtml( message ).replace( "\n", "<br>" )
+				+ "</body></html>";
+		panel.add(new JLabel( messageHtml ), "wrap");
 		panel.add( showDetailsLabel, "wrap");
 		panel.add(scrollPane, "grow");
 		return panel;

--- a/src/test/java/org/mastodon/blender/ExceptionMessageDialogDemo.java
+++ b/src/test/java/org/mastodon/blender/ExceptionMessageDialogDemo.java
@@ -34,7 +34,7 @@ public class ExceptionMessageDialogDemo
 {
 	public static void main(String... args) {
 		Exception e = getSomeExceptions();
-		System.out.println( ExceptionDialog.showOkCancelDialog( null, "Some Error Occurred", "This is what went wrong", e, "Hello", "Cancel" ));
+		System.out.println( ExceptionDialog.showOkCancelDialog( null, "Some Error Occurred", "This is what went wrong.\nAnd another line of text.", e, "Hello", "Cancel" ));
 	}
 
 	private static Exception getSomeExceptions()


### PR DESCRIPTION
Increase timeout when starting Blender. This might avoid a timeout that occured when using Blender 4.2. At the same time users might get the impression that the program hangs.

Improve text formatting of exceptions in the error message dialog.