### PR TITLE
Bump dependencies: pom-scijava to 42.0.0 and mastodon to 1.0.0-beta-35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>40.0.0</version>
+        <version>42.0.0</version>
 	</parent>
 
 	<groupId>org.mastodon</groupId>
@@ -98,7 +98,7 @@
 		<license.excludes>**/zip.xml</license.excludes>
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
-		<mastodon.version>1.0.0-beta-34</mastodon.version>
+        <mastodon.version>1.0.0-beta-35</mastodon.version>
 	</properties>
 
 	<build>


### PR DESCRIPTION
This pull request updates project dependencies in the `pom.xml` file to use newer versions. These changes ensure compatibility with the latest releases and may include important bug fixes and improvements.

Dependency version updates:

* Updated the parent `pom-scijava` version from `40.0.0` to `42.0.0` to use the latest SciJava build configuration.
* Updated the `mastodon.version` property from `1.0.0-beta-34` to `1.0.0-beta-35` to use the latest Mastodon release.