### PR TITLE
Fix issue #20 by specifying explicit target path for depencies install

### DIFF
--- a/src/main/resources/blender-scripts/install_addon.py
+++ b/src/main/resources/blender-scripts/install_addon.py
@@ -33,6 +33,7 @@ import bpy
 import sys
 import addon_utils
 from pathlib import Path
+from site import getsitepackages
 
 # install pip
 
@@ -53,9 +54,12 @@ os.environ.pop("PIP_REQ_TRACKER", None)
 # install dependencies
 
 python_path = get_python_path()
-target = Path(python_path).parent.parent/"lib"/"site-packages"
+for path in getsitepackages():
+    if "site-packages" in path:
+        target = path
+        break
 packages = {'grpcio', 'bidict', 'grpcio-tools', 'pandas'}
-subprocess.check_output([python_path, '-m', 'pip', 'install', "--upgrade", '--target', str(target), *packages])
+subprocess.check_output([python_path, '-m', 'pip', 'install', '--target', str(target), *packages])
 
 # test if dependencies are installed
 

--- a/src/main/resources/blender-scripts/install_addon.py
+++ b/src/main/resources/blender-scripts/install_addon.py
@@ -32,6 +32,7 @@ import subprocess
 import bpy
 import sys
 import addon_utils
+from pathlib import Path
 
 # install pip
 
@@ -52,8 +53,9 @@ os.environ.pop("PIP_REQ_TRACKER", None)
 # install dependencies
 
 python_path = get_python_path()
+target = Path(python_path).parent.parent/"lib"/"site-packages"
 packages = {'grpcio', 'bidict', 'grpcio-tools', 'pandas'}
-subprocess.check_output([python_path, '-m', 'pip', 'install', *packages])
+subprocess.check_output([python_path, '-m', 'pip', 'install', "--upgrade", '--target', str(target), *packages])
 
 # test if dependencies are installed
 


### PR DESCRIPTION
See my comment on https://github.com/mastodon-sc/mastodon-blender-view/issues/20. 

It seems that on Windows, for some reason Python looks at `site-packages` from distributions elsewhere in the computer, notably in `AppData/Roaming/Python`. 
I think this is fixed by specifying explicitly the target path for the dependencies to be installed in:

```py
python_path = get_python_path()
target = Path(python_path).parent.parent/"lib"/"site-packages" # in Blender's Python distribution
packages = {'grpcio', 'bidict', 'grpcio-tools', 'pandas'}
subprocess.check_output([python_path, '-m', 'pip', 'install', "--upgrade", '--target', str(target), *packages])
```

Since this path was implicit in situations where this problem doesn't occur, this change should be inconsequential to those situations.

From what I've tested on my end this works in both the situation with the issue and the situation without the issue.