### PR TITLE
Install python dependencies into mastodon-blender-view/libs/ folder, fixes #20

### DIFF
--- a/blender-addon/__init__.py
+++ b/blender-addon/__init__.py
@@ -37,6 +37,21 @@ bl_info = {
     "category": "3D View"
 }
 
+
+def add_addon_libs_dir():
+    """
+    Add the dependencies of the Mastodon Blender View plugin to the pythons system path.
+    """
+    import sys
+    import os
+    addon_dir = os.path.dirname(__file__)
+    addon_libs_dir = os.path.join(addon_dir, "libs")
+    if addon_libs_dir not in sys.path:
+        sys.path.insert(0, addon_libs_dir)
+
+
+add_addon_libs_dir()
+
 from . import mb_panel
 from . import mb_server
 

--- a/blender-addon/__init__.py
+++ b/blender-addon/__init__.py
@@ -38,10 +38,8 @@ bl_info = {
 }
 
 
-def add_addon_libs_dir():
-    """
-    Add the dependencies of the Mastodon Blender View plugin to the pythons system path.
-    """
+def _add_dependencies_to_sys_path():
+    """ Add the dependencies of Mastodon Blender View addon to the pythons system path. """
     import sys
     import os
     addon_dir = os.path.dirname(__file__)
@@ -50,7 +48,7 @@ def add_addon_libs_dir():
         sys.path.insert(0, addon_libs_dir)
 
 
-add_addon_libs_dir()
+_add_dependencies_to_sys_path()
 
 from . import mb_panel
 from . import mb_server

--- a/src/main/resources/blender-scripts/install_addon.py
+++ b/src/main/resources/blender-scripts/install_addon.py
@@ -33,7 +33,21 @@ import bpy
 import sys
 import addon_utils
 
+# install addon
+
+print("start installing mastodon blender view addon...")
+argv = sys.argv
+addon_zip = argv[argv.index('--') + 1]
+bpy.ops.preferences.addon_install(filepath=addon_zip)
+print("mastodon blender view addon installed")
+
 # install pip
+
+os.environ.pop("PIP_REQ_TRACKER", None)
+ensurepip.bootstrap()
+os.environ.pop("PIP_REQ_TRACKER", None)
+
+# get python path
 
 def get_python_path():
     try:
@@ -44,40 +58,40 @@ def get_python_path():
         path = sys.executable
     return os.path.abspath(path)
 
-
-os.environ.pop("PIP_REQ_TRACKER", None)
-ensurepip.bootstrap()
-os.environ.pop("PIP_REQ_TRACKER", None)
-
-# install dependencies
-
 python_path = get_python_path()
-packages = {'grpcio', 'bidict', 'grpcio-tools', 'pandas'}
-subprocess.check_output([python_path, '-m', 'pip', 'install', *packages])
 
-# test if dependencies are installed
+print(f"Blender python binary: {python_path}")
 
-try:
-    import bidict
-    import grpc
-    import google.protobuf
-    import pandas
-except ModuleNotFoundError:
-    raise Exception("dependency installation failed")
-
-print("dependencies installed")
-
-# install addon
-
-argv = sys.argv
-addon_zip = argv[argv.index('--') + 1]
-bpy.ops.preferences.addon_install(filepath=addon_zip)
-
-print("mastodon blender view addon installed")
+# get installation path of "mastodon_blender_view" folder
 
 filename_init_py = [m.__file__ for m in addon_utils.modules() if m.__name__ == "mastodon_blender_view"][0]
 addon_dir = os.path.dirname(filename_init_py)
-subprocess.check_output([python_path, '-m', 'grpc_tools.protoc', '-I.', '--python_out=.', '--grpc_python_out=.', 'mastodon_blender_view/mastodon-blender-view.proto'], cwd=os.path.dirname(addon_dir))
+print(f"Installation directory of the Blender Mastodon plugin: {addon_dir}")
+
+# install dependencies
+
+addon_libs_dir = os.path.join(addon_dir, "libs")
+print(f"Install dependencies into folder: {addon_libs_dir}")
+
+packages = ['grpcio', 'bidict', 'grpcio-tools', 'pandas']
+subprocess.check_call([python_path, "-m", "pip", "install", "--target", addon_libs_dir, *packages])
+
+if addon_libs_dir not in sys.path: # add addon libs dir to system path
+    sys.path.insert(0, addon_libs_dir)
+
+import bidict
+import grpc
+import google.protobuf
+import pandas
+
+print("dependencies installed")
+
+# install google rpc protocol
+cmd = [python_path, '-m', 'grpc_tools.protoc', '-I.', '--python_out=.', '--grpc_python_out=.', 'mastodon_blender_view/mastodon-blender-view.proto']
+cwd = path.dirname(addon_dir)
+env = os.environ.copy()
+env["PYTHONPATH"] = addon_libs_dir + os.pathsep + env.get("PYTHONPATH") if "PYTHONPATH" in env else addon_libs_dir
+subprocess.check_output(cmd, cwd=os.cwd, env=env )
 
 try:
     from mastodon_blender_view import mastodon_blender_view_pb2

--- a/src/main/resources/blender-scripts/install_addon.py
+++ b/src/main/resources/blender-scripts/install_addon.py
@@ -33,21 +33,72 @@ import bpy
 import sys
 import addon_utils
 
-# install addon
 
-print("start installing mastodon blender view addon...")
-argv = sys.argv
-addon_zip = argv[argv.index('--') + 1]
-bpy.ops.preferences.addon_install(filepath=addon_zip)
-print("mastodon blender view addon installed")
+def main():
+    print("start installing mastodon blender view addon...")
+    install_mastodon_blender_view_addon()
+    print("mastodon blender view addon installed")
+    print("install pip if needed...")
+    install_pip()
+    print("pip is installed")
+    addon_dir = get_mastodon_blender_view_addon_dir()
+    print(f"Installation directory of the Mastodon Blender View addon: {addon_dir}")
+    install_dependencies(packages=['grpcio', 'bidict', 'grpcio-tools', 'pandas'], target=os.path.join(addon_dir, "libs"))
+    import_dependencies()
+    print("dependencies installed")
+    compile_grpc_protocol(addon_dir)
+    print("google RPC code compiled")
 
-# install pip
 
-os.environ.pop("PIP_REQ_TRACKER", None)
-ensurepip.bootstrap()
-os.environ.pop("PIP_REQ_TRACKER", None)
+def install_mastodon_blender_view_addon():
+    argv = sys.argv
+    addon_zip = argv[argv.index('--') + 1]
+    bpy.ops.preferences.addon_install(filepath=addon_zip)
 
-# get python path
+
+def install_pip():
+    os.environ.pop("PIP_REQ_TRACKER", None)
+    ensurepip.bootstrap()
+    os.environ.pop("PIP_REQ_TRACKER", None)
+
+
+def get_mastodon_blender_view_addon_dir() -> str:
+    filename_init_py = [m.__file__ for m in addon_utils.modules() if m.__name__ == "mastodon_blender_view"][0]
+    addon_dir = os.path.dirname(filename_init_py)
+    return addon_dir
+
+
+def install_dependencies(packages: list[str], target: str):
+    print(f"Install dependencies into folder: {target}")
+
+    subprocess.check_call([get_python_path(), "-m", "pip", "install", "--target", target, *packages])
+
+    if target not in sys.path:  # add addon libs dir to system path
+        sys.path.insert(0, target)
+
+
+def import_dependencies():
+    import bidict
+    import grpc
+    import google.protobuf
+    import pandas
+
+
+def compile_grpc_protocol(addon_dir):
+    cmd = [get_python_path(), '-m', 'grpc_tools.protoc', '-I.', '--python_out=.', '--grpc_python_out=.',
+           'mastodon_blender_view/mastodon-blender-view.proto']
+    cwd = os.path.dirname(addon_dir)
+    env = os.environ.copy()
+    addon_libs_dir = os.path.join(addon_dir, "libs")
+    env["PYTHONPATH"] = addon_libs_dir + os.pathsep + env.get("PYTHONPATH") if "PYTHONPATH" in env else addon_libs_dir
+    subprocess.check_output(cmd, cwd=cwd, env=env)
+
+    try:
+        from mastodon_blender_view import mastodon_blender_view_pb2
+        from mastodon_blender_view import mastodon_blender_view_pb2_grpc
+    except ModuleNotFoundError:
+        raise Exception("installing google RPC generated code failed")
+
 
 def get_python_path():
     try:
@@ -58,45 +109,5 @@ def get_python_path():
         path = sys.executable
     return os.path.abspath(path)
 
-python_path = get_python_path()
 
-print(f"Blender python binary: {python_path}")
-
-# get installation path of "mastodon_blender_view" folder
-
-filename_init_py = [m.__file__ for m in addon_utils.modules() if m.__name__ == "mastodon_blender_view"][0]
-addon_dir = os.path.dirname(filename_init_py)
-print(f"Installation directory of the Blender Mastodon plugin: {addon_dir}")
-
-# install dependencies
-
-addon_libs_dir = os.path.join(addon_dir, "libs")
-print(f"Install dependencies into folder: {addon_libs_dir}")
-
-packages = ['grpcio', 'bidict', 'grpcio-tools', 'pandas']
-subprocess.check_call([python_path, "-m", "pip", "install", "--target", addon_libs_dir, *packages])
-
-if addon_libs_dir not in sys.path: # add addon libs dir to system path
-    sys.path.insert(0, addon_libs_dir)
-
-import bidict
-import grpc
-import google.protobuf
-import pandas
-
-print("dependencies installed")
-
-# install google rpc protocol
-cmd = [python_path, '-m', 'grpc_tools.protoc', '-I.', '--python_out=.', '--grpc_python_out=.', 'mastodon_blender_view/mastodon-blender-view.proto']
-cwd = path.dirname(addon_dir)
-env = os.environ.copy()
-env["PYTHONPATH"] = addon_libs_dir + os.pathsep + env.get("PYTHONPATH") if "PYTHONPATH" in env else addon_libs_dir
-subprocess.check_output(cmd, cwd=os.cwd, env=env )
-
-try:
-    from mastodon_blender_view import mastodon_blender_view_pb2
-    from mastodon_blender_view import mastodon_blender_view_pb2_grpc
-except ModuleNotFoundError:
-    raise Exception("installing google RPC generated code failed")
-
-print("google RPC code compiled")
+main()

--- a/src/main/resources/csv/read_csv.py
+++ b/src/main/resources/csv/read_csv.py
@@ -28,6 +28,9 @@
 ###
 import os
 import bpy
+
+bpy.ops.preferences.addon_enable(module='mastodon_blender_view')
+
 import pandas as pd
 import csv
 from collections import defaultdict

--- a/src/main/resources/csv/read_csv.py
+++ b/src/main/resources/csv/read_csv.py
@@ -29,7 +29,7 @@
 import os
 import bpy
 
-bpy.ops.preferences.addon_enable(module='mastodon_blender_view')
+bpy.ops.preferences.addon_enable(module='mastodon_blender_view') # "pandas" can only be imported after enabling the addon
 
 import pandas as pd
 import csv


### PR DESCRIPTION
The python dependencies: 
- pandas, 
- bidict,
- grpcio and grpcio-tools
are now installed into folder that Blender choses for the "mastodon-blender-view". Into a subfolder called `libs/`.

This way to install dependencies is the preferred way for Blender Addons prior to Blender 4.2. [see here](https://github.com/robertguetzkow/blender-python-examples/blob/92214a9d74eedad8572e890a374d5204623c796a/add_ons/install_dependencies/README.md)

(Big thanks to @smlpt and @ChrisMzz, for reporting and investigating installation problems #20 and #36.
@ChrisMzz suggested that providing a proper target folder (flag `--target`) hen running `pip install`, fixes some installation problem. However the question what is a proper target folder remains. PR #36 now implements it's own rule of thumb for determining the target, which would probably work.)

The cleanest way to solve issue #20 would be to follow the Blender Manual, and deploy dependencies as wheels. [see Blender Manual - Python Wheels](https://docs.blender.org/manual/en/4.2/advanced/extensions/python_wheels.html)
This would however drastically increase the effort for deploying the Mastodon Blender plugin. And only newer Blender version would be supported Blender > 4.2.